### PR TITLE
Endpoint Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,23 @@ To use `minitest-openapi`, add `require 'minitest/openapi'` to
 the top of your request spec, and the `document!` method at the top of 
 your class declaration.
 
-The `document!` method can take in one of a few 'descriptors': `:path`, `:webhook`,
-or `:component`. The `:path` descriptor is set by default if nothing is passed in.
+By default, test cases are evaluated as `paths`. That is, 
+they're not `webhooks` or `components`. If a test case is testing a 
+`webhook`, call `webhook!` within the test block.
 
 ```rb
 require 'minitest/openapi'
 
 class WebhookControllerTest < ActionDispatch::IntegrationTest
-  document! :webhook
+  document!
+  
+  test "GET /" do 
+    get root_path
+    assert_response :success
+  end
 
   test "POST /webhook" do
+    webhook!
     post webhook_path
     assert_response :success
   end

--- a/lib/minitest/openapi/endpoint_builder.rb
+++ b/lib/minitest/openapi/endpoint_builder.rb
@@ -12,6 +12,8 @@ module Minitest
 
           endpoint = {}
           filtered_path = @request.filtered_path || 'unknown'
+
+          # TODO: find a better name
           request_activity = activity
 
           endpoint[filtered_path] = request_activity
@@ -20,8 +22,18 @@ module Minitest
 
         private
 
+        # TODO:
+        # 1. Find a better name
+        # 2. Research if Minitest supports metadata
+        #    (minispec-metadata/minitest-metadata/custom option)
         def activity
-          { http_method: @request.method, status: @response.status }
+          {
+            summary: "",
+            description: "",
+            status: @response.status,
+            http_operation: @request.method,
+            parameters: {}
+          }
         end
       end
     end

--- a/lib/minitest/openapi/endpoint_builder.rb
+++ b/lib/minitest/openapi/endpoint_builder.rb
@@ -9,10 +9,12 @@ module Minitest
         request, response = Minitest::OpenAPI::ParseRequest.call(context)
         return if request.nil?
 
-        {
-          http_method: request.method,
-          status: response.status
-        }
+        endpoint = {}
+        filtered_path = request.filtered_path || 'unknown'
+        request_activity = { http_method: request.method, status: response.status }
+
+        endpoint[filtered_path] = request_activity
+        endpoint
       end
     end
   end

--- a/lib/minitest/openapi/endpoint_builder.rb
+++ b/lib/minitest/openapi/endpoint_builder.rb
@@ -5,16 +5,24 @@ require 'action_dispatch'
 module Minitest
   module OpenAPI
     module EndpointBuilder
-      def self.call(context, _test)
-        request, response = Minitest::OpenAPI::ParseRequest.call(context)
-        return if request.nil?
+      class << self
+        def call(context, _test)
+          @request, @response = Minitest::OpenAPI::ParseRequest.call(context)
+          return if @request.nil?
 
-        endpoint = {}
-        filtered_path = request.filtered_path || 'unknown'
-        request_activity = { http_method: request.method, status: response.status }
+          endpoint = {}
+          filtered_path = @request.filtered_path || 'unknown'
+          request_activity = activity
 
-        endpoint[filtered_path] = request_activity
-        endpoint
+          endpoint[filtered_path] = request_activity
+          endpoint
+        end
+
+        private
+
+        def activity
+          { http_method: @request.method, status: @response.status }
+        end
       end
     end
   end

--- a/lib/minitest/openapi/minitest_hook.rb
+++ b/lib/minitest/openapi/minitest_hook.rb
@@ -31,11 +31,11 @@ module Minitest
   end
 end
 
+# TODO: Refactor into its own file
 module MinitestOpenAPIMethods
   def self.prepended(base)
     base.extend(Document)
 
-    # instance methods
     base.class_eval do
       def webhook?
         @webhook
@@ -47,7 +47,6 @@ module MinitestOpenAPIMethods
     end
   end
 
-  # class methods
   module Document
     def document?
       @document

--- a/lib/minitest/openapi/minitest_hook.rb
+++ b/lib/minitest/openapi/minitest_hook.rb
@@ -54,5 +54,8 @@ if ENV['DOC']
     puts '============================='
     puts 'Building Docs 🎉'
     puts '============================='
+    puts "\n"
+
+    pp Minitest::OpenAPI.paths
   end
 end

--- a/lib/minitest/openapi/minitest_hook.rb
+++ b/lib/minitest/openapi/minitest_hook.rb
@@ -5,7 +5,7 @@ require 'minitest'
 module Minitest
   module OpenAPI
     DESCRIPTORS = %i[path webhook component].freeze
-    FileContext = Struct.new(:path)
+    TestCase = Struct.new(:path)
 
     module RunPatch
       def run(*args)
@@ -14,10 +14,10 @@ module Minitest
 
         if DESCRIPTORS.include?(self.class.document_type)
           test_file_path = result.source_location.first
-          test_file_ctx = FileContext.new(test_file_path)
+          test_case = TestCase.new(test_file_path)
 
-          export_file_path = Minitest::OpenAPI.path.yield_self { |p| p.is_a?(Proc) ? p.call(test_file_ctx) : p }
-          endpoint_data = Minitest::OpenAPI::EndpointBuilder.call(self, test_file_ctx) || {}
+          export_file_path = Minitest::OpenAPI.path.yield_self { |p| p.is_a?(Proc) ? p.call(test_case) : p }
+          endpoint_data = Minitest::OpenAPI::EndpointBuilder.call(self, test_case) || {}
 
           # TODO: Change this to work for paths or webhooks
           Minitest::OpenAPI.paths[export_file_path] << endpoint_data
@@ -51,11 +51,6 @@ if ENV['DOC']
   Minitest::Test.prepend Minitest::OpenAPI::RunPatch
 
   Minitest.after_run do
-    puts '============================='
-    puts 'Building Docs 🎉'
-    puts '============================='
-    puts "\n"
-
     pp Minitest::OpenAPI.paths
   end
 end


### PR DESCRIPTION
*NOT FINISHED*

This PR adds the ability to split test documentation into separate files, and establishes the logic to build the [Path Item Object](https://spec.openapis.org/oas/latest.html#pathItemObject) for each endpoint. Endpoints that belong to either the `paths` object and `webhooks` object must adhere to the `Path Item Object` pattern.

```json
"paths" : ["Path Item Object"],
"webhooks": ["Path Item Object"],
========================

"paths": [
   "path_name": {
      "$ref": "string",
      "summary": "string",
      "description": "string",
      "method": "Operation Object",
      "options": "Operation Object",
      "head": "Operation Object",
      "patch": "Operation Object",
      "trace": "Operation Object",
      "servers": "Server Object",
      "parameters": "Parameter Object"
   }
]
```